### PR TITLE
Refactor image_packer to be importable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ lib64
 pip-log.txt
 
 # Unit test / coverage reports
+.cache
 .coverage
 .tox
 nosetests.xml

--- a/image_packer.py
+++ b/image_packer.py
@@ -19,6 +19,12 @@ try:
 except ImportError:
     pass
 
+DEFAULT_INSPEC = "*.png"
+DEFAULT_OUTFILE = "output.png"
+DEFAULT_SIZE = (1024, 1024)
+DEFAULT_LARGEST_FIRST = False
+DEFAULT_TEMPFILES = False
+
 
 def tuple_arg(s):
     try:
@@ -76,56 +82,72 @@ class PackNode(object):
                 self.area[0], self.area[1],
                 self.area[0]+area.width, self.area[1]+area.height))
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description='Pack multiple images of different sizes into one image.',
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument(
-        '-i', '--inspec', default='*.png',
-        help='Input file spec')
-    parser.add_argument(
-        '-o', '--outfile', default='output.png',
-        help='Output image file')
-    parser.add_argument(
-        '-s', '--size', type=tuple_arg, metavar='pixels',
-        help="Size (width,height tuple) of the image we're packing into",
-        default="1024,1024")
-    parser.add_argument(
-        '-l', '--largest_first', action='store_true',
-        help='Pack largest images first')
-    parser.add_argument(
-        '-t', '--tempfiles', action='store_true',
-        help='Save temporary files to show filling')
-    args = parser.parse_args()
-    print(args)
+
+def image_packer(inspec=DEFAULT_INSPEC,
+                 outfile=DEFAULT_OUTFILE,
+                 size=DEFAULT_SIZE,
+                 largest_first=DEFAULT_LARGEST_FIRST,
+                 tempfiles=DEFAULT_TEMPFILES):
 
     im_format = 'RGBA'
-    #get a list of PNG files in the current directory
-    names = glob.glob(args.inspec)
-    if args.outfile in names:
-        names.remove(args.outfile)  # don't include any pre-existing output
+    # Get a list of PNG files in the current directory
+    names = glob.glob(inspec)
+    if outfile in names:
+        names.remove(outfile)  # Don't include any pre-existing output
 
-    #create a list of PIL Image objects, sorted by size
+    # Create a list of PIL Image objects, sorted by size
     print("Create a list of PIL Image objects, sorted by size")
-    images = sorted([(i.size[0]*i.size[1], name, i) for name, i in ((x, Image.open(x).convert(im_format)) for x in names)], reverse=args.largest_first)
+    images = sorted([(i.size[0]*i.size[1], name, i) for name, i in (
+                        (x,
+                         Image.open(x).convert(im_format)) for x in names)],
+                    reverse=largest_first)
 
     print("Create tree")
-    tree = PackNode(args.size)
-    image = Image.new(im_format, args.size)
+    tree = PackNode(size)
+    image = Image.new(im_format, size)
 
-    #insert each image into the PackNode area
+    # Insert each image into the PackNode area
     for i, (area, name, img) in enumerate(images):
         print(name, img.size)
         uv = tree.insert(img.size)
         if uv is None:
             raise ValueError(
-                'Pack size ' + str(args.size) + ' too small, cannot insert ' +
+                'Pack size ' + str(size) + ' too small, cannot insert ' +
                 str(img.size) + ' image.')
         image.paste(img, uv.area)
-        if args.tempfiles:
+        if tempfiles:
             image.save("temp" + str(i).zfill(4) + ".png")
 
-    image.save(args.outfile)
+    image.save(outfile)
     image.show()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='Pack multiple images of different sizes into one image.',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '-i', '--inspec', default=DEFAULT_INSPEC,
+        help='Input file spec')
+    parser.add_argument(
+        '-o', '--outfile', default=DEFAULT_OUTFILE,
+        help='Output image file')
+    parser.add_argument(
+        '-s', '--size', type=tuple_arg, metavar='pixels',
+        help="Size (width,height tuple) of the image we're packing into",
+        default=DEFAULT_SIZE)
+    parser.add_argument(
+        '-l', '--largest_first', action='store_true',
+        help='Pack largest images first',
+        default=DEFAULT_LARGEST_FIRST)
+    parser.add_argument(
+        '-t', '--tempfiles', action='store_true',
+        help='Save temporary files to show filling',
+        default=DEFAULT_TEMPFILES)
+    args = parser.parse_args()
+    print(args)
+
+    image_packer(args.inspec, args.outfile, args.size, args.largest_first,
+                 args.tempfiles)
 
 # End of file

--- a/test_pixel_tools.py
+++ b/test_pixel_tools.py
@@ -4,7 +4,6 @@ Tests for pixel tools
 """
 import argparse
 import os
-import sys
 import unittest
 
 import imp
@@ -126,7 +125,7 @@ class TestPixelTools(unittest.TestCase):
         # cmd = "face_cropper.py"
         # outdir = "face_cropper"
         # args = " -c haarcascade_frontalface_alt.xml -i " + self.inspec + \
-            # " -o " + outdir
+        #    " -o " + outdir
         # self.helper_set_up(cmd)
         # outspec = os.path.join(outdir, self.inspec.strip('"'))
         # import glob
@@ -166,6 +165,25 @@ class TestPixelTools(unittest.TestCase):
 
         # Assert
         self.assertTrue(os.path.isfile(self.outfile))
+
+    def test_image_packer_tuple_arg(self):
+        """Test tuple_arg works as expected"""
+        # Arrange
+        from image_packer import tuple_arg
+
+        # Act
+        out1 = tuple_arg("12, 34")
+        out2 = tuple_arg("12,34")
+        out3 = tuple_arg("12:34")
+        out4 = tuple_arg("12x34")
+
+        # Assert
+        self.assertEqual(out1, (12, 34))
+        self.assertEqual(out2, (12, 34))
+        self.assertEqual(out3, (12, 34))
+        self.assertEqual(out4, (12, 34))
+        with self.assertRaises(argparse.ArgumentTypeError):
+            tuple_arg("1234")
 
     def test_normalise_mean(self):
         """Just test with some options and check an output file is created"""


### PR DESCRIPTION
For #3.

For example:

```python
from image_packer import image_packer

image_packer("11*.jpg", "/tmp/out.png", (4048, 4048))
```

Works like:
```bash
python image_packer.py -i "11*.jpg" -o /tmp/out.png -s 4048,4048
```