### PR TITLE
Replace pypy3.8 with pypy3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.8", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["pypy3.10", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos